### PR TITLE
[BUGFIX] Only reBuild if TYPO3 uses composer class loading

### DIFF
--- a/Classes/Utility/ClassCacheManager.php
+++ b/Classes/Utility/ClassCacheManager.php
@@ -79,7 +79,8 @@ class ClassCacheManager
     {
         if (empty($parameters)
             || (
-                !empty($parameters['cacheCmd'])
+                \TYPO3\CMS\Core\Core\Bootstrap::usesComposerClassLoading()
+                && !empty($parameters['cacheCmd'])
                 && GeneralUtility::inList('all,system', $parameters['cacheCmd'])
                 && isset($GLOBALS['BE_USER'])
             )


### PR DESCRIPTION
I have got an Exception when TYPO3 does not use composer class loading if I don't check it before rebuilding the class cache.