### PR TITLE
Use dependency injection in ClassCacheManager

### DIFF
--- a/Classes/Utility/ClassLoader.php
+++ b/Classes/Utility/ClassLoader.php
@@ -108,8 +108,7 @@ class ClassLoader implements \TYPO3\CMS\Core\SingletonInterface
                  * @var \Evoweb\Extender\Utility\ClassCacheManager $classCacheManager
                  */
                 $classCacheManager = GeneralUtility::makeInstance(
-                    \Evoweb\Extender\Utility\ClassCacheManager::class,
-                    $this->getClassCache()
+                    \Evoweb\Extender\Utility\ClassCacheManager::class
                 );
                 $classCacheManager->reBuild();
             }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,11 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  Evoweb\Extender\:
+    resource: '../Classes/*'
+
+  Evoweb\Extender\Utility\ClassCacheManager:
+    public: true

--- a/Tests/Functional/Utility/AbstractTestBase.php
+++ b/Tests/Functional/Utility/AbstractTestBase.php
@@ -9,6 +9,13 @@ class AbstractTestBase extends \TYPO3\TestingFramework\Core\Functional\Functiona
     /**
      * @var array
      */
+    protected $testExtensionsToLoad = [
+        'typo3conf/ext/extender',
+    ];
+
+    /**
+     * @var array
+     */
     protected $cacheConfiguration = [
         'frontend' => \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class,
         'backend' => \TYPO3\CMS\Core\Cache\Backend\FileBackend::class,

--- a/Tests/Functional/Utility/ClassCacheManagerTest.php
+++ b/Tests/Functional/Utility/ClassCacheManagerTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Evoweb\Extender\Tests\Functional\Utility;
 
+use Composer\Autoload\ClassLoader;
+use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\AccessibleObjectInterface;
@@ -15,10 +17,16 @@ class ClassCacheManagerTest extends AbstractTestBase
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = $this->createMock(\TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class);
 
+        /** @var \TYPO3\CMS\Core\Cache\CacheManager $cacheManagerMock */
+        $cacheManagerMock = $this->createMock(CacheManager::class);
+        $cacheManagerMock->method('getCache')->with('extender')->will($this->returnValue($cacheMock));
+
+        $composerClassLoader = GeneralUtility::getContainer()->get(\Composer\Autoload\ClassLoader::class);
+
         /** @var \Evoweb\Extender\Utility\ClassCacheManager $subject */
         $subject = $this->getMockBuilder($this->buildAccessibleProxy(\Evoweb\Extender\Utility\ClassCacheManager::class))
             ->onlyMethods(['parseSingleFile'])
-            ->setConstructorArgs([$cacheMock])
+            ->setConstructorArgs([$composerClassLoader, $cacheManagerMock])
             ->enableProxyingToOriginalMethods()
             ->getMock();
 
@@ -71,10 +79,16 @@ class ClassCacheManagerTest extends AbstractTestBase
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = $this->createMock(\TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class);
 
+        /** @var \TYPO3\CMS\Core\Cache\CacheManager $cacheManagerMock */
+        $cacheManagerMock = $this->createMock(CacheManager::class);
+        $cacheManagerMock->method('getCache')->with('extender')->will($this->returnValue($cacheMock));
+
+        $composerClassLoader = GeneralUtility::getContainer()->get(\Composer\Autoload\ClassLoader::class);
+
         /** @var \Evoweb\Extender\Utility\ClassCacheManager|AccessibleObjectInterface $subject */
         $subject = $this->getMockBuilder($this->buildAccessibleProxy(\Evoweb\Extender\Utility\ClassCacheManager::class))
             ->onlyMethods(['parseSingleFile', '_get'])
-            ->setConstructorArgs([$cacheMock])
+            ->setConstructorArgs([$composerClassLoader, $cacheManagerMock])
             ->enableProxyingToOriginalMethods()
             ->getMock();
 
@@ -162,10 +176,16 @@ class ClassCacheManagerTest extends AbstractTestBase
             ['extender', $cacheBackend]
         );
 
+        /** @var \TYPO3\CMS\Core\Cache\CacheManager $cacheManagerMock */
+        $cacheManagerMock = $this->createMock(CacheManager::class);
+        $cacheManagerMock->method('getCache')->with('extender')->will($this->returnValue($cacheMock));
+
+        $composerClassLoader = GeneralUtility::getContainer()->get(\Composer\Autoload\ClassLoader::class);
+
         /** @var \Evoweb\Extender\Utility\ClassCacheManager|AccessibleObjectInterface $subject */
         $subject = $this->getMockBuilder($this->buildAccessibleProxy(\Evoweb\Extender\Utility\ClassCacheManager::class))
             ->onlyMethods(['parseSingleFile', '_get'])
-            ->setConstructorArgs([$cacheMock])
+            ->setConstructorArgs([$composerClassLoader, $cacheManagerMock])
             ->enableProxyingToOriginalMethods()
             ->getMock();
 
@@ -244,10 +264,16 @@ class ClassCacheManagerTest extends AbstractTestBase
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = $this->createMock(\TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class);
 
+        /** @var \TYPO3\CMS\Core\Cache\CacheManager $cacheManagerMock */
+        $cacheManagerMock = $this->createMock(CacheManager::class);
+        $cacheManagerMock->method('getCache')->with('extender')->will($this->returnValue($cacheMock));
+
+        $composerClassLoader = GeneralUtility::getContainer()->get(\Composer\Autoload\ClassLoader::class);
+
         /** @var \Evoweb\Extender\Utility\ClassCacheManager $subject */
         $subject = $this->getMockBuilder($this->buildAccessibleProxy(\Evoweb\Extender\Utility\ClassCacheManager::class))
             ->onlyMethods(['changeCode'])
-            ->setConstructorArgs([$cacheMock])
+            ->setConstructorArgs([$composerClassLoader, $cacheManagerMock])
             ->enableProxyingToOriginalMethods()
             ->getMock();
 
@@ -286,10 +312,16 @@ class Blob extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = $this->createMock(\TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class);
 
+        /** @var \TYPO3\CMS\Core\Cache\CacheManager $cacheManagerMock */
+        $cacheManagerMock = $this->createMock(CacheManager::class);
+        $cacheManagerMock->method('getCache')->with('extender')->will($this->returnValue($cacheMock));
+
+        $composerClassLoader = GeneralUtility::getContainer()->get(\Composer\Autoload\ClassLoader::class);
+
         /** @var \Evoweb\Extender\Utility\ClassCacheManager $subject */
         $subject = $this->getMockBuilder($this->buildAccessibleProxy(\Evoweb\Extender\Utility\ClassCacheManager::class))
             ->onlyMethods(['getPartialInfo'])
-            ->setConstructorArgs([$cacheMock])
+            ->setConstructorArgs([$composerClassLoader, $cacheManagerMock])
             ->enableProxyingToOriginalMethods()
             ->getMock();
 
@@ -309,10 +341,16 @@ class Blob extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = $this->createMock(\TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class);
 
+        /** @var \TYPO3\CMS\Core\Cache\CacheManager $cacheManagerMock */
+        $cacheManagerMock = $this->createMock(CacheManager::class);
+        $cacheManagerMock->method('getCache')->with('extender')->will($this->returnValue($cacheMock));
+
+        $composerClassLoader = GeneralUtility::getContainer()->get(\Composer\Autoload\ClassLoader::class);
+
         /** @var \Evoweb\Extender\Utility\ClassCacheManager $subject */
         $subject = $this->getMockBuilder($this->buildAccessibleProxy(\Evoweb\Extender\Utility\ClassCacheManager::class))
             ->onlyMethods(['closeClassDefinition'])
-            ->setConstructorArgs([$cacheMock])
+            ->setConstructorArgs([$composerClassLoader, $cacheManagerMock])
             ->enableProxyingToOriginalMethods()
             ->getMock();
 
@@ -333,7 +371,13 @@ class Blob extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = new \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend('extender', $cacheBackend);
 
-        $subject = new \Evoweb\Extender\Utility\ClassCacheManager($cacheMock);
+        /** @var \TYPO3\CMS\Core\Cache\CacheManager $cacheManagerMock */
+        $cacheManagerMock = $this->createMock(CacheManager::class);
+        $cacheManagerMock->method('getCache')->with('extender')->will($this->returnValue($cacheMock));
+
+        $composerClassLoader = GeneralUtility::getContainer()->get(\Composer\Autoload\ClassLoader::class);
+
+        $subject = new \Evoweb\Extender\Utility\ClassCacheManager($composerClassLoader, $cacheManagerMock);
         $subject->reBuild();
 
         $cacheEntryIdentifier = GeneralUtility::underscoredToLowerCamelCase('base_extension') . '_' .
@@ -432,7 +476,13 @@ class Blob extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = new \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend('extender', $cacheBackend);
 
-        $subject = new \Evoweb\Extender\Utility\ClassCacheManager($cacheMock);
+        /** @var \TYPO3\CMS\Core\Cache\CacheManager $cacheManagerMock */
+        $cacheManagerMock = $this->createMock(CacheManager::class);
+        $cacheManagerMock->method('getCache')->with('extender')->will($this->returnValue($cacheMock));
+
+        $composerClassLoader = GeneralUtility::getContainer()->get(\Composer\Autoload\ClassLoader::class);
+
+        $subject = new \Evoweb\Extender\Utility\ClassCacheManager($composerClassLoader, $cacheManagerMock);
         $subject->reBuild();
 
         $cacheEntryIdentifier = GeneralUtility::underscoredToLowerCamelCase('base_extension') . '_' .
@@ -582,7 +632,13 @@ class BlobWithStorage extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = new \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend('extender', $cacheBackend);
 
-        $subject = new \Evoweb\Extender\Utility\ClassCacheManager($cacheMock);
+        /** @var \TYPO3\CMS\Core\Cache\CacheManager $cacheManagerMock */
+        $cacheManagerMock = $this->createMock(CacheManager::class);
+        $cacheManagerMock->method('getCache')->with('extender')->will($this->returnValue($cacheMock));
+
+        $composerClassLoader = GeneralUtility::getContainer()->get(\Composer\Autoload\ClassLoader::class);
+
+        $subject = new \Evoweb\Extender\Utility\ClassCacheManager($composerClassLoader, $cacheManagerMock);
         $subject->reBuild();
 
         $cacheEntryIdentifier = GeneralUtility::underscoredToLowerCamelCase('base_extension') . '_' .
@@ -708,7 +764,13 @@ class AnotherBlob extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = new \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend('extender', $cacheBackend);
 
-        $subject = new \Evoweb\Extender\Utility\ClassCacheManager($cacheMock);
+        /** @var \TYPO3\CMS\Core\Cache\CacheManager $cacheManagerMock */
+        $cacheManagerMock = $this->createMock(CacheManager::class);
+        $cacheManagerMock->method('getCache')->with('extender')->will($this->returnValue($cacheMock));
+
+        $composerClassLoader = GeneralUtility::getContainer()->get(\Composer\Autoload\ClassLoader::class);
+
+        $subject = new \Evoweb\Extender\Utility\ClassCacheManager($composerClassLoader, $cacheManagerMock);
         $subject->reBuild();
 
         $cacheEntryIdentifier = GeneralUtility::underscoredToLowerCamelCase('base_extension') . '_' .

--- a/composer.json
+++ b/composer.json
@@ -45,5 +45,8 @@
 	},
 	"require-dev": {
 		"typo3/testing-framework": "~5.0.11"
+	},
+	"scripts": {
+		"post-autoload-dump": "mkdir -p .Build/Web/typo3conf/ext/ && ln -snf ../../../.. .Build/Web/typo3conf/ext/extender"
 	}
 }


### PR DESCRIPTION
As we require TYPO3 v10, we can rely on the
new system wide dependency injection container.

This removes `GeneralUtility::getContainer()` usage, as `getContainer` should be avoided
whenever possible ([IoC](https://en.wikipedia.org/wiki/Inversion_of_control)).