### PR TITLE
Use dependency injection for ClassLoader

### DIFF
--- a/Classes/Utility/ClassCacheManager.php
+++ b/Classes/Utility/ClassCacheManager.php
@@ -14,7 +14,7 @@ namespace Evoweb\Extender\Utility;
  */
 
 use Composer\Autoload\ClassLoader;
-use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Cache\Frontend\PhpFrontend;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -25,7 +25,7 @@ class ClassCacheManager
     /**
      * Cache instance
      *
-     * @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend
+     * @var PhpFrontend
      */
     protected $classCache;
 
@@ -35,11 +35,6 @@ class ClassCacheManager
     protected $composerClassLoader;
 
     /**
-     * @var CacheManager
-     */
-    protected $cacheManager;
-
-    /**
      * @var array
      */
     protected $constructorLines = [];
@@ -47,15 +42,15 @@ class ClassCacheManager
     /**
      * Constructor
      *
+     * @param PhpFrontend $classCache
      * @param ClassLoader $composerClassLoader
-     * @param CacheManager $cacheManager
      */
     public function __construct(
-        ClassLoader $composerClassLoader,
-        CacheManager $cacheManager
+        PhpFrontend $classCache,
+        ClassLoader $composerClassLoader
     ) {
+        $this->classCache = $classCache;
         $this->composerClassLoader = $composerClassLoader;
-        $this->cacheManager = $cacheManager;
     }
 
     /**
@@ -120,21 +115,10 @@ class ClassCacheManager
                     // Add the new file to the class cache
                     $cacheEntryIdentifier = GeneralUtility::underscoredToLowerCamelCase($extensionKey) . '_' .
                         str_replace('\\', '_', $entity);
-                    $this->getClassCache()->set($cacheEntryIdentifier, $code);
+                    $this->classCache->set($cacheEntryIdentifier, $code);
                 }
             }
         }
-    }
-
-    /**
-     * @return \TYPO3\CMS\Core\Cache\Frontend\FrontendInterface|\TYPO3\CMS\Core\Cache\Frontend\PhpFrontend|null
-     */
-    protected function getClassCache(): \TYPO3\CMS\Core\Cache\Frontend\FrontendInterface
-    {
-        if (is_null($this->classCache)) {
-            $this->classCache = $this->cacheManager->getCache('extender');
-        }
-        return $this->classCache;
     }
 
     /**

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,11 +1,22 @@
 services:
   _defaults:
-    autowire: true
-    autoconfigure: true
+    autowire: false
+    autoconfigure: false
     public: false
 
-  Evoweb\Extender\:
-    resource: '../Classes/*'
+  extender.cache:
+    class: TYPO3\CMS\Core\Cache\Frontend\PhpFrontend
+    # We can not use CacheManager, as it can not be
+    # injected/instantiated during ext_localconf.php loading
+    # factory: ['@TYPO3\CMS\Core\Cache\CacheManager', 'getCache']
+    # therefore we use the static Bootstrap::createCache factory instead.
+    factory: ['TYPO3\CMS\Core\Core\Bootstrap', 'createCache']
+    arguments: ['extender']
 
   Evoweb\Extender\Utility\ClassCacheManager:
+    arguments: ['@extender.cache', '@Composer\Autoload\ClassLoader']
+    public: true
+
+  Evoweb\Extender\Utility\ClassLoader:
+    arguments: ['@extender.cache', '@Evoweb\Extender\Utility\ClassCacheManager']
     public: true

--- a/Tests/Functional/Utility/ClassCacheManagerTest.php
+++ b/Tests/Functional/Utility/ClassCacheManagerTest.php
@@ -3,7 +3,6 @@ namespace Evoweb\Extender\Tests\Functional\Utility;
 
 use Composer\Autoload\ClassLoader;
 use PHPUnit\Framework\MockObject\MockObject;
-use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\AccessibleObjectInterface;
@@ -18,19 +17,12 @@ class ClassCacheManagerTest extends AbstractTestBase
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = $this->createMock(\TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class);
 
-        /** @var CacheManager|MockObject $cacheManagerMock */
-        $cacheManagerMock = $this->createMock(CacheManager::class);
-        $cacheManagerMock
-            ->method('getCache')
-            ->with('extender')
-            ->will($this->returnValue($cacheMock));
-
         $composerClassLoader = GeneralUtility::getContainer()->get(ClassLoader::class);
 
         /** @var \Evoweb\Extender\Utility\ClassCacheManager $subject */
         $subject = $this->getMockBuilder($this->buildAccessibleProxy(\Evoweb\Extender\Utility\ClassCacheManager::class))
             ->onlyMethods(['parseSingleFile'])
-            ->setConstructorArgs([$composerClassLoader, $cacheManagerMock])
+            ->setConstructorArgs([$cacheMock, $composerClassLoader])
             ->enableProxyingToOriginalMethods()
             ->getMock();
 
@@ -83,19 +75,12 @@ class ClassCacheManagerTest extends AbstractTestBase
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = $this->createMock(\TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class);
 
-        /** @var CacheManager|MockObject $cacheManagerMock */
-        $cacheManagerMock = $this->createMock(CacheManager::class);
-        $cacheManagerMock
-            ->method('getCache')
-            ->with('extender')
-            ->will($this->returnValue($cacheMock));
-
         $composerClassLoader = GeneralUtility::getContainer()->get(ClassLoader::class);
 
         /** @var \Evoweb\Extender\Utility\ClassCacheManager|AccessibleObjectInterface $subject */
         $subject = $this->getMockBuilder($this->buildAccessibleProxy(\Evoweb\Extender\Utility\ClassCacheManager::class))
             ->onlyMethods(['parseSingleFile', '_get'])
-            ->setConstructorArgs([$composerClassLoader, $cacheManagerMock])
+            ->setConstructorArgs([$cacheMock, $composerClassLoader])
             ->enableProxyingToOriginalMethods()
             ->getMock();
 
@@ -183,19 +168,12 @@ class ClassCacheManagerTest extends AbstractTestBase
             ['extender', $cacheBackend]
         );
 
-        /** @var CacheManager|MockObject $cacheManagerMock */
-        $cacheManagerMock = $this->createMock(CacheManager::class);
-        $cacheManagerMock
-            ->method('getCache')
-            ->with('extender')
-            ->will($this->returnValue($cacheMock));
-
         $composerClassLoader = GeneralUtility::getContainer()->get(ClassLoader::class);
 
         /** @var \Evoweb\Extender\Utility\ClassCacheManager|AccessibleObjectInterface $subject */
         $subject = $this->getMockBuilder($this->buildAccessibleProxy(\Evoweb\Extender\Utility\ClassCacheManager::class))
             ->onlyMethods(['parseSingleFile', '_get'])
-            ->setConstructorArgs([$composerClassLoader, $cacheManagerMock])
+            ->setConstructorArgs([$cacheMock, $composerClassLoader])
             ->enableProxyingToOriginalMethods()
             ->getMock();
 
@@ -274,19 +252,12 @@ class ClassCacheManagerTest extends AbstractTestBase
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = $this->createMock(\TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class);
 
-        /** @var CacheManager|MockObject $cacheManagerMock */
-        $cacheManagerMock = $this->createMock(CacheManager::class);
-        $cacheManagerMock
-            ->method('getCache')
-            ->with('extender')
-            ->will($this->returnValue($cacheMock));
-
         $composerClassLoader = GeneralUtility::getContainer()->get(ClassLoader::class);
 
         /** @var \Evoweb\Extender\Utility\ClassCacheManager $subject */
         $subject = $this->getMockBuilder($this->buildAccessibleProxy(\Evoweb\Extender\Utility\ClassCacheManager::class))
             ->onlyMethods(['changeCode'])
-            ->setConstructorArgs([$composerClassLoader, $cacheManagerMock])
+            ->setConstructorArgs([$cacheMock, $composerClassLoader])
             ->enableProxyingToOriginalMethods()
             ->getMock();
 
@@ -325,19 +296,12 @@ class Blob extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = $this->createMock(\TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class);
 
-        /** @var CacheManager|MockObject $cacheManagerMock */
-        $cacheManagerMock = $this->createMock(CacheManager::class);
-        $cacheManagerMock
-            ->method('getCache')
-            ->with('extender')
-            ->will($this->returnValue($cacheMock));
-
         $composerClassLoader = GeneralUtility::getContainer()->get(ClassLoader::class);
 
         /** @var \Evoweb\Extender\Utility\ClassCacheManager $subject */
         $subject = $this->getMockBuilder($this->buildAccessibleProxy(\Evoweb\Extender\Utility\ClassCacheManager::class))
             ->onlyMethods(['getPartialInfo'])
-            ->setConstructorArgs([$composerClassLoader, $cacheManagerMock])
+            ->setConstructorArgs([$cacheMock, $composerClassLoader])
             ->enableProxyingToOriginalMethods()
             ->getMock();
 
@@ -357,19 +321,12 @@ class Blob extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = $this->createMock(\TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class);
 
-        /** @var CacheManager|MockObject $cacheManagerMock */
-        $cacheManagerMock = $this->createMock(CacheManager::class);
-        $cacheManagerMock
-            ->method('getCache')
-            ->with('extender')
-            ->will($this->returnValue($cacheMock));
-
         $composerClassLoader = GeneralUtility::getContainer()->get(ClassLoader::class);
 
         /** @var \Evoweb\Extender\Utility\ClassCacheManager $subject */
         $subject = $this->getMockBuilder($this->buildAccessibleProxy(\Evoweb\Extender\Utility\ClassCacheManager::class))
             ->onlyMethods(['closeClassDefinition'])
-            ->setConstructorArgs([$composerClassLoader, $cacheManagerMock])
+            ->setConstructorArgs([$cacheMock, $composerClassLoader])
             ->enableProxyingToOriginalMethods()
             ->getMock();
 
@@ -390,16 +347,9 @@ class Blob extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = new \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend('extender', $cacheBackend);
 
-        /** @var CacheManager|MockObject $cacheManagerMock */
-        $cacheManagerMock = $this->createMock(CacheManager::class);
-        $cacheManagerMock
-            ->method('getCache')
-            ->with('extender')
-            ->will($this->returnValue($cacheMock));
-
         $composerClassLoader = GeneralUtility::getContainer()->get(ClassLoader::class);
 
-        $subject = new \Evoweb\Extender\Utility\ClassCacheManager($composerClassLoader, $cacheManagerMock);
+        $subject = new \Evoweb\Extender\Utility\ClassCacheManager($cacheMock, $composerClassLoader);
         $subject->reBuild();
 
         $cacheEntryIdentifier = GeneralUtility::underscoredToLowerCamelCase('base_extension') . '_' .
@@ -498,16 +448,9 @@ class Blob extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = new \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend('extender', $cacheBackend);
 
-        /** @var CacheManager|MockObject $cacheManagerMock */
-        $cacheManagerMock = $this->createMock(CacheManager::class);
-        $cacheManagerMock
-            ->method('getCache')
-            ->with('extender')
-            ->will($this->returnValue($cacheMock));
-
         $composerClassLoader = GeneralUtility::getContainer()->get(ClassLoader::class);
 
-        $subject = new \Evoweb\Extender\Utility\ClassCacheManager($composerClassLoader, $cacheManagerMock);
+        $subject = new \Evoweb\Extender\Utility\ClassCacheManager($cacheMock, $composerClassLoader);
         $subject->reBuild();
 
         $cacheEntryIdentifier = GeneralUtility::underscoredToLowerCamelCase('base_extension') . '_' .
@@ -657,16 +600,9 @@ class BlobWithStorage extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = new \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend('extender', $cacheBackend);
 
-        /** @var CacheManager|MockObject $cacheManagerMock */
-        $cacheManagerMock = $this->createMock(CacheManager::class);
-        $cacheManagerMock
-            ->method('getCache')
-            ->with('extender')
-            ->will($this->returnValue($cacheMock));
-
         $composerClassLoader = GeneralUtility::getContainer()->get(ClassLoader::class);
 
-        $subject = new \Evoweb\Extender\Utility\ClassCacheManager($composerClassLoader, $cacheManagerMock);
+        $subject = new \Evoweb\Extender\Utility\ClassCacheManager($cacheMock, $composerClassLoader);
         $subject->reBuild();
 
         $cacheEntryIdentifier = GeneralUtility::underscoredToLowerCamelCase('base_extension') . '_' .
@@ -792,16 +728,9 @@ class AnotherBlob extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = new \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend('extender', $cacheBackend);
 
-        /** @var CacheManager|MockObject $cacheManagerMock */
-        $cacheManagerMock = $this->createMock(CacheManager::class);
-        $cacheManagerMock
-            ->method('getCache')
-            ->with('extender')
-            ->will($this->returnValue($cacheMock));
-
         $composerClassLoader = GeneralUtility::getContainer()->get(ClassLoader::class);
 
-        $subject = new \Evoweb\Extender\Utility\ClassCacheManager($composerClassLoader, $cacheManagerMock);
+        $subject = new \Evoweb\Extender\Utility\ClassCacheManager($cacheMock, $composerClassLoader);
         $subject->reBuild();
 
         $cacheEntryIdentifier = GeneralUtility::underscoredToLowerCamelCase('base_extension') . '_' .

--- a/Tests/Functional/Utility/ClassLoaderTest.php
+++ b/Tests/Functional/Utility/ClassLoaderTest.php
@@ -2,6 +2,7 @@
 namespace Evoweb\Extender\Tests\Functional\Utility;
 
 use Evoweb\Extender\Utility\ClassLoader;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ClassLoaderTest extends AbstractTestBase
 {
@@ -12,8 +13,9 @@ class ClassLoaderTest extends AbstractTestBase
     {
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = $this->createMock(\TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class);
+        $classCacheManager = new \Evoweb\Extender\Utility\ClassCacheManager($cacheMock, GeneralUtility::getContainer()->get(\Composer\Autoload\ClassLoader::class));
 
-        $subject = new \Evoweb\Extender\Utility\ClassLoader($cacheMock);
+        $subject = new \Evoweb\Extender\Utility\ClassLoader($cacheMock, $classCacheManager);
         $subject::registerAutoloader();
 
         $autoLoaders = spl_autoload_functions();
@@ -39,11 +41,12 @@ class ClassLoaderTest extends AbstractTestBase
     {
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = $this->createMock(\TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class);
+        $classCacheManager = new \Evoweb\Extender\Utility\ClassCacheManager($cacheMock, GeneralUtility::getContainer()->get(\Composer\Autoload\ClassLoader::class));
 
         /** @var \Evoweb\Extender\Utility\ClassLoader $subject */
         $subject = $this->getMockBuilder($this->buildAccessibleProxy(\Evoweb\Extender\Utility\ClassLoader::class))
             ->onlyMethods(['isExcludedClassName'])
-            ->setConstructorArgs([$cacheMock])
+            ->setConstructorArgs([$cacheMock, $classCacheManager])
             ->enableProxyingToOriginalMethods()
             ->getMock();
 
@@ -58,11 +61,12 @@ class ClassLoaderTest extends AbstractTestBase
     {
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = $this->createMock(\TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class);
+        $classCacheManager = new \Evoweb\Extender\Utility\ClassCacheManager($cacheMock, GeneralUtility::getContainer()->get(\Composer\Autoload\ClassLoader::class));
 
         /** @var \Evoweb\Extender\Utility\ClassLoader $subject */
         $subject = $this->getMockBuilder($this->buildAccessibleProxy(\Evoweb\Extender\Utility\ClassLoader::class))
             ->onlyMethods(['getExtensionKeyFromNamespace'])
-            ->setConstructorArgs([$cacheMock])
+            ->setConstructorArgs([$cacheMock, $classCacheManager])
             ->enableProxyingToOriginalMethods()
             ->getMock();
 
@@ -80,11 +84,12 @@ class ClassLoaderTest extends AbstractTestBase
     {
         /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend $cacheMock */
         $cacheMock = $this->createMock(\TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class);
+        $classCacheManager = new \Evoweb\Extender\Utility\ClassCacheManager($cacheMock, GeneralUtility::getContainer()->get(\Composer\Autoload\ClassLoader::class));
 
         /** @var \Evoweb\Extender\Utility\ClassLoader $subject */
         $subject = $this->getMockBuilder($this->buildAccessibleProxy(\Evoweb\Extender\Utility\ClassLoader::class))
             ->onlyMethods(['isValidClassName'])
-            ->setConstructorArgs([$cacheMock])
+            ->setConstructorArgs([$cacheMock, $classCacheManager])
             ->enableProxyingToOriginalMethods()
             ->getMock();
 
@@ -112,7 +117,9 @@ class ClassLoaderTest extends AbstractTestBase
         $cacheMock->expects($this->any())->method('has')->will($this->returnValue(true));
         $cacheMock->expects($this->any())->method('requireOnce')->will($this->returnValue(true));
 
-        $subject = new \Evoweb\Extender\Utility\ClassLoader($cacheMock);
+        $classCacheManager = new \Evoweb\Extender\Utility\ClassCacheManager($cacheMock, GeneralUtility::getContainer()->get(\Composer\Autoload\ClassLoader::class));
+
+        $subject = new \Evoweb\Extender\Utility\ClassLoader($cacheMock, $classCacheManager);
 
         $className = \Fixture\BaseExtension\Domain\Model\Blob::class;
         $condition = $subject->loadClass($className);


### PR DESCRIPTION
Avoid CacheManager usage, as that would be needed to be
lazy loaded, as we need to instantiate our ClassLoader
instance during ext_localconf.php load.
Use Bootsrap::createCache as factory for our cache.
Adapt ClassCacheManager to use the this cache as well.

We need manual wiring for our custom cache anyway,
so we disable autowiring.

TODO:
 * Maybe refactor to be executed once Core\Bootstrap::init completes.
   Problem: There is no event/hook available.
   Possible solution: We could theoretically intercept the Core\Context
   class factory, that class is loaded for every request (frontend,backend,cli).
   Which means we could register our autoloader at that time.