### PR TITLE
[FIX] class autoloader for CLI

### DIFF
--- a/Classes/Utility/ClassCacheManager.php
+++ b/Classes/Utility/ClassCacheManager.php
@@ -65,13 +65,14 @@ class ClassCacheManager
             if (PHP_SAPI === 'cli') {
                 $autoloaderFolders = [
                     trim(shell_exec('pwd')) . '/vendor/',
-                    __DIR__ . '/../vendor/'
+                    PATH_site . '/../vendor/'
                 ];
                 foreach ($autoloaderFolders as $autoloaderFolder) {
                     if (file_exists($autoloaderFolder . 'autoload.php')) {
                         $classLoaderFilePath = $autoloaderFolder . 'autoload.php';
                         /* @noinspection PhpIncludeInspection */
                         $this->composerClassLoader = require $classLoaderFilePath;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
- use PATH_site instead of __DIR__ constant. "typo3cms" can be called from anywhere, thus __DIR__ (= working directory) can be anything. PATH_site makes much more sense and this constant is available at least since TYPO3 6.2.

- break foreach once a "autoload.php" has been found.

see #22