### PR TITLE
Register autoloader via an early event

### DIFF
--- a/Classes/Event/RegisterAutoloaderEvent.php
+++ b/Classes/Event/RegisterAutoloaderEvent.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evoweb\Extender\Event;
+
+/*
+ * This file is part of the "extender" Extension for TYPO3 CMS.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+use Evoweb\Extender\Utility\ClassLoader;
+use Psr\Container\ContainerInterface;
+use Psr\EventDispatcher\StoppableEventInterface;
+use TYPO3\CMS\Core\Cache\Backend\FileBackend;
+use TYPO3\CMS\Core\Cache\Frontend\PhpFrontend;
+
+class RegisterAutoloaderEvent implements StoppableEventInterface
+{
+    public function __construct(ContainerInterface $container)
+    {
+        // Register extender cache
+        // needs to stay above autoloader registration to always have settings before using the cache
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['extender'] = [
+            'frontend' => PhpFrontend::class,
+            'backend' => FileBackend::class,
+            'groups' => [
+                'all',
+                'system',
+            ],
+            'options' => [
+                'defaultLifetime' => 0,
+            ],
+        ];
+
+        spl_autoload_register([$container->get(ClassLoader::class), 'loadClass'], true, true);
+    }
+
+    public function isPropagationStopped() : bool
+    {
+        return true;
+    }
+}

--- a/Classes/Utility/ClassLoader.php
+++ b/Classes/Utility/ClassLoader.php
@@ -34,14 +34,6 @@ class ClassLoader implements SingletonInterface
         'Symfony\Polyfill\Mbstring\Mbstring'
     ];
 
-    /**
-     * Register instance of this class as spl autoloader
-     */
-    public static function registerAutoloader()
-    {
-        spl_autoload_register([GeneralUtility::makeInstance(self::class), 'loadClass'], true, true);
-    }
-
     public function __construct(PhpFrontend $classCache, ClassCacheManager $classCacheManager)
     {
         $this->classCache = $classCache;

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evoweb\Extender;
+
+use Evoweb\Extender\Utility\ClassLoader;
+use Evoweb\Extender\Event\RegisterAutoloaderEvent;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\DependencyInjection\Reference;
+
+return static function (ContainerConfigurator $container, ContainerBuilder $containerBuilder) {
+    $containerBuilder->addCompilerPass(new class() implements CompilerPassInterface {
+        public function process(ContainerBuilder $container): void
+        {
+            $eventDispatcher = $container->findDefinition(EventDispatcherInterface::class);
+            if ($eventDispatcher) {
+                $event = new Definition(RegisterAutoloaderEvent::class);
+                $event->setArguments([new Reference('service_container')]);
+                $event->setShared(false);
+                $eventDispatcher->addMethodCall('dispatch', [$event]);
+            }
+        }
+    });
+};

--- a/Tests/Functional/Utility/ClassLoaderTest.php
+++ b/Tests/Functional/Utility/ClassLoaderTest.php
@@ -20,7 +20,7 @@ class ClassLoaderTest extends AbstractTestBase
         );
 
         $subject = new \Evoweb\Extender\Utility\ClassLoader($cacheMock, $classCacheManager);
-        $subject::registerAutoloader();
+        spl_autoload_register([$subject, 'loadClass'], true, true);
 
         $autoLoaders = spl_autoload_functions();
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,24 +3,6 @@
 defined('TYPO3') or die();
 
 call_user_func(function () {
-    // Register extender cache
-    // needs to stay above registerAutoloader to always have settings before using the cache
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['extender'] = [
-        'frontend' => \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class,
-        'backend' => \TYPO3\CMS\Core\Cache\Backend\FileBackend::class,
-        'groups' => [
-            'all',
-            'system',
-        ],
-        'options' => [
-            'defaultLifetime' => 0,
-        ],
-    ];
-
-    if (class_exists(\Evoweb\Extender\Utility\ClassLoader::class)) {
-        \Evoweb\Extender\Utility\ClassLoader::registerAutoloader();
-    }
-
     // Configure clear cache post processing for extended domain model
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] =
         \Evoweb\Extender\Utility\ClassCacheManager::class . '->reBuild';


### PR DESCRIPTION
The event dispatcher is created prior loading of
ext_localconf, therefore an early event is now
attached in order to load the extender autoloader
at an early stage.

The event is added via a compiler pass that modifies
the event dispatcher factory in order to dispatch
the desired event on demand.