### PR TITLE
Add cache factory to centralize registration of cache configuration

### DIFF
--- a/Classes/Event/RegisterAutoloaderEvent.php
+++ b/Classes/Event/RegisterAutoloaderEvent.php
@@ -18,28 +18,11 @@ namespace Evoweb\Extender\Event;
 use Evoweb\Extender\Utility\ClassLoader;
 use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\StoppableEventInterface;
-use TYPO3\CMS\Core\Cache\Backend\AbstractBackend;
-use TYPO3\CMS\Core\Cache\Backend\FileBackend;
-use TYPO3\CMS\Core\Cache\Frontend\PhpFrontend;
 
 class RegisterAutoloaderEvent implements StoppableEventInterface
 {
     public function __construct(ContainerInterface $container)
     {
-        // Register extender cache
-        // needs to stay above autoloader registration to always have settings before using the cache
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['extender'] = [
-            'frontend' => PhpFrontend::class,
-            'backend' => FileBackend::class,
-            'groups' => [
-                'all',
-                'system',
-            ],
-            'options' => [
-                'defaultLifetime' => AbstractBackend::UNLIMITED_LIFETIME,
-            ],
-        ];
-
         spl_autoload_register([$container->get(ClassLoader::class), 'loadClass'], true, true);
     }
 

--- a/Classes/Utility/ClassCacheFactory.php
+++ b/Classes/Utility/ClassCacheFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evoweb\Extender\Utility;
+
+/*
+ * This file is part of the "extender" Extension for TYPO3 CMS.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Cache\Backend\AbstractBackend;
+use TYPO3\CMS\Core\Cache\Backend\FileBackend;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+use TYPO3\CMS\Core\Cache\Frontend\PhpFrontend;
+
+class ClassCacheFactory
+{
+    public function createCache(): FrontendInterface
+    {
+        self::configureCache();
+        return Bootstrap::createCache('extender');
+    }
+
+    public static function configureCache(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['extender'] = [
+            'frontend' => PhpFrontend::class,
+            'backend' => FileBackend::class,
+            'groups' => [
+                'all',
+                'system',
+            ],
+            'options' => [
+                'defaultLifetime' => AbstractBackend::UNLIMITED_LIFETIME,
+            ],
+        ];
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -10,11 +10,9 @@ services:
   extender.cache:
     class: TYPO3\CMS\Core\Cache\Frontend\PhpFrontend
     # We can not use CacheManager, as it can not be
-    # injected/instantiated during ext_localconf.php loading
-    # factory: ['@TYPO3\CMS\Core\Cache\CacheManager', 'getCache']
-    # therefore we use the static Bootstrap::createCache factory instead.
-    factory: ['TYPO3\CMS\Core\Core\Bootstrap', 'createCache']
-    arguments: ['extender']
+    # injected/instantiated prior (or during) ext_localconf.php
+    # loading therefore we use an own factory instead.
+    factory: ['@Evoweb\Extender\Utility\ClassCacheFactory', 'createCache']
 
   Evoweb\Extender\Command\ExtenderRebuildCommand:
     arguments: ['@Evoweb\Extender\Utility\ClassCacheManager']

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,6 +3,8 @@
 defined('TYPO3') or die();
 
 call_user_func(function () {
+    \Evoweb\Extender\Utility\ClassCacheFactory::configureCache();
+
     // Configure clear cache post processing for extended domain model
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] =
         \Evoweb\Extender\Utility\ClassCacheManager::class . '->reBuild';


### PR DESCRIPTION
…and ensure that the cache configuration is always
present (for consistency), even if the core wouldn't
create an EventDispatcher instance.