### PR TITLE
[BUGFIX] Improved check for existing files

### DIFF
--- a/Classes/Utility/ClassCacheManager.php
+++ b/Classes/Utility/ClassCacheManager.php
@@ -52,17 +52,19 @@ class ClassCacheManager
     public function build(string $cacheEntryIdentifier, string $className): void
     {
         // Get the file to extend, this needs to be loaded as first
-        $path = $this->composerClassLoader->findFile($className);
-        if (!is_file($path)) {
-            throw new BaseFileNotFoundException('Base file "' . $path . '" does not exist');
+        $path = $this->composerClassLoader->findFile($entity);
+        if ($path === false || !is_file($path)) {
+            throw new FileNotFoundException(
+                'Base file "' . $path . '" does not exist for ' . $entity
+            );
         }
         $code = $this->parseSingleFile($path, false);
 
         // Get the files from all other extensions that are extending this domain model
         foreach ($this->register->getExtendingClasses($className) as $extendingEntity) {
             $path = $this->composerClassLoader->findFile($extendingEntity);
-            if (!is_file($path)) {
-                throw new ExtendingFileNotFoundException('Extending file "' . $path . '" does not exist');
+            if ($path === false || !is_file($path)) {
+                throw new ExtendingFileNotFoundException('Extending file "' . $path . '" does not exist for ' . $extendingEntity);
             }
             $code .= $this->parseSingleFile($path);
         }


### PR DESCRIPTION
Doing currently an upgrade to v12 and getting the following error

```
is_file(): Argument #1 ($filename) must be of type string, bool given
```

of course this is my fault because the file I am extending is not yet available but the error is totally not helpful and can be easily changed to improve code quality and better help for users

getting now

`Base file "" does not exist for JWeiland\Events2\Domain\Model\Event`