### PR TITLE
Draft: [FIX][#42] fixing caching for missing model-proxy after cache-flush

### DIFF
--- a/Classes/Hooks/ClearCacheHook.php
+++ b/Classes/Hooks/ClearCacheHook.php
@@ -25,6 +25,10 @@ class ClearCacheHook
             if ($this->cacheManager->hasCache('extbase_reflection')) {
                 $this->cacheManager->getCache('extbase_reflection')?->flush();
             }
+
+            if ($this->cacheManager->hasCache('classes')) {
+                $this->cacheManager->getCache('classes')?->flush();
+            }
         }
     }
 }

--- a/Classes/Hooks/ClearCacheHook.php
+++ b/Classes/Hooks/ClearCacheHook.php
@@ -2,14 +2,17 @@
 
 namespace Evoweb\Extender\Hooks;
 
+use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Frontend\PhpFrontend;
 use TYPO3\CMS\Core\Core\Environment;
 
 class ClearCacheHook
 {
-    public function __construct(protected PhpFrontend $classCache)
-    {
-    }
+    public function __construct(
+        protected PhpFrontend $classCache,
+        protected CacheManager $cacheManager
+    )
+    {}
 
     /**
      * @param array<non-empty-string, string|string[]> $parameters
@@ -18,6 +21,10 @@ class ClearCacheHook
     {
         if (Environment::getContext()->isDevelopment() && ($parameters['cacheCmd'] ?? '') === 'all') {
             $this->classCache->flush();
+
+            if ($this->cacheManager->hasCache('extbase_reflection')) {
+                $this->cacheManager->getCache('extbase_reflection')?->flush();
+            }
         }
     }
 }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -48,6 +48,7 @@ services:
     public: true
     arguments:
       $classCache: '@cache.extender'
+      $cacheManager: '@TYPO3\CMS\Core\Cache\CacheManager'
 
   Evoweb\Extender\Loader\ClassLoader:
     arguments:


### PR DESCRIPTION
Only left tiny culprit is, that in TYPO3 backend the flash-message shown usually after cache flush does not appear anymore. But there is no exception/error - so this is less critical, than non-working frontend after a cache-flush happening.

If you accept my PR I would be glad to be mentioned for contribution :) 