### PR TITLE
Merge static::configuration with Typo3-configured

### DIFF
--- a/Classes/Cache/CacheFactory.php
+++ b/Classes/Cache/CacheFactory.php
@@ -52,7 +52,7 @@ class CacheFactory
 
     public static function addClassCacheConfigToGlobalTypo3ConfVars(): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['extender'] = static::$configuration;
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['extender'] = array_replace_recursive(static::$configuration, $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['extender']);
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']['extender'] =
             ClearCacheHook::class . '->clearCachePostProc';
     }


### PR DESCRIPTION
Respect the pre-configured cache-configuration (settings/additional.php) from TYPO3
(missing ['options']['cacheDirectory'])